### PR TITLE
Add user creation at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ that allows to spin an instance with a fresh database in a breeze.
   <img src="https://raw.githubusercontent.com/play-with-docker/stacks/master/assets/images/button.png" alt="Try in Play With Docker"/>
 </a>
 
+Once the instance is running you can login with user `tmi@tmi.local` and password `play.with.docker`.
+
 ## Usage
 
 _to be documented_

--- a/app/Console/Commands/MakeAdminCommand.php
+++ b/app/Console/Commands/MakeAdminCommand.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use App\Actions\Fortify\CreateNewUser;
+use Illuminate\Validation\ValidationException;
+
+class MakeAdminCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'tmi:admin
+                            {--email= : The user email address.}
+                            {--password= : The user password.}
+                            {--name= : The user name to use. Default the email user.}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create an admin user';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $email = $this->option('email');
+        $name = $this->option('name') ?? $this->getUsernameFrom($email);
+        $password = $this->option('password');
+            
+        if (empty($password) && $this->input->isInteractive()) {
+            $password = $this->secret("Please specify an 8 character password for the administrator");
+        }
+
+        $createUserAction = new CreateNewUser();
+
+        try{
+            $user = $createUserAction->create([
+                'name' => $name,
+                'email' => $email,
+                'password' => $password,
+                'password_confirmation' => $password,
+            ]);
+            
+            $user->role = User::ROLE_MANAGER;
+            $user->save();
+    
+            $this->line('');
+            $this->line("TMI Administrator, <comment>$email</comment>, created.");       
+            $this->line('');
+    
+            return self::SUCCESS;
+        }
+        catch(ValidationException $ex)
+        {
+            if($ex->validator->errors()->has('email') && 
+               $ex->validator->errors()->first('email') === 'The email has already been taken.'){
+
+                $this->line('');
+                $this->error("User already existing");
+                $this->line('');
+
+                return self::INVALID;
+            }
+  
+
+            $this->line('');
+            $this->error("Validation errors");
+            $this->line('');
+
+            foreach ($ex->errors() as $key => $messages) {
+                $this->comment($key);
+
+                foreach ($messages as $message) {
+                    $this->line("  - {$message}");
+                }
+                $this->line('');
+            }
+
+            return self::FAILURE;
+        }
+
+    }
+
+    private function getUsernameFrom($email)
+    {
+        $et_offset = strpos($email, '@');
+        return $et_offset !== false ? substr($email, 0, $et_offset) : $email;
+    }
+}

--- a/deploy/pwd.yml
+++ b/deploy/pwd.yml
@@ -25,6 +25,8 @@ services:
             DB_PASSWORD: '${DB_PASSWORD:-password}'
             # APP_URL: http://localhost:8080
             QUEUE_CONNECTION: sync
+            ADMIN_USERNAME: "tmi@tmi.local"
+            ADMIN_PASSWORD: "play.with.docker"
         networks:
             - sail
         depends_on:

--- a/docker/configure.sh
+++ b/docker/configure.sh
@@ -125,9 +125,9 @@ function write_config() {
 
 function update() {
     cd "${DIR}" || return 242
-    echo "- Launching update procedure..."
-    su -s /bin/sh -c "php artisan migrate --force" $SETUP_USER
-    # create_admin
+    echo "- Launching update procedure..." || return 242
+    su -s /bin/sh -c "php artisan migrate --force" $SETUP_USER || return 242
+    create_admin || return 242
 }
 
 function wait_mariadb () {
@@ -162,7 +162,7 @@ function create_admin () {
     if [ -z "$ADMIN_USERNAME" ] &&  [ -z "$ADMIN_PASSWORD" ]; then
         # if both username and password are not defined or empty, tell to create the user afterwards an end return
         echo "**************"
-        echo "Remember to create an admin user: php artisan create-admin --help"
+        echo "Remember to create an admin user: php artisan tmi:admin --help"
         echo "**************"
         return 0
     fi
@@ -178,12 +178,12 @@ function create_admin () {
     if [ -n "$ADMIN_USERNAME" ] &&  [ -z "$ADMIN_PASSWORD" ]; then
         # username set, but empty password => the user needs to be created after the setup
         echo "**************"
-        echo "Skipping creation of default administrator. Use php artisan create-admin after the startup is complete."
+        echo "Skipping creation of default administrator. Use php artisan tmi:admin after the startup is complete."
         echo "**************"
         return 0
     fi
 
-    su -s /bin/sh -c "php artisan create-admin '$ADMIN_USERNAME' --password '$ADMIN_PASSWORD'" $SETUP_USER
+    su -s /bin/sh -c "php artisan tmi:admin -n --email '$ADMIN_USERNAME' --password '$ADMIN_PASSWORD'" $SETUP_USER
 
     local ret=$?
     if [ $ret -eq 2 ]; then


### PR DESCRIPTION
Closes #14 

- Add `tmi:admin` command to create an admin user using the CLI
- Configure Docker startup script to execute `tmi:admin` if `ADMIN_USERNAME` and `ADMIN_PASSWORD` environment variables are configured