### PR TITLE
Take into account teams and members when showing projects

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -15,9 +15,13 @@ class DashboardController extends Controller
      */
     public function __invoke(Request $request)
     {
+        $user = $request->user();
+
+        $team = $user->currentTeam()->first();
 
         return view('dashboard', [
-            'projects' => Project::with('members')->get(),
+            'projects' => Project::with('members')->ofTeam($team)->get(),
+            'team' => $team,
         ]);
     }
 }

--- a/app/Http/Controllers/ProjectController.php
+++ b/app/Http/Controllers/ProjectController.php
@@ -14,12 +14,17 @@ class ProjectController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request)
     {
         $this->authorize(Project::class);
+
+        $user = $request->user();
+
+        $team = $user->currentTeam()->first();
         
         return view('projects.index', [
-            'projects' => Project::with('members')->get(),
+            'projects' => Project::with('members')->ofTeam($team)->get(),
+            'team' => $team,
         ]);
     }
 

--- a/app/Http/Livewire/ProjectInput.php
+++ b/app/Http/Livewire/ProjectInput.php
@@ -94,10 +94,15 @@ class ProjectInput extends Component
     public function fetchAutocomplete()
     {
         // TODO: define query scopes for ordering by latest updated/latest added task
+
+        /** @var \App\Models\User */
+        $user = auth()->user();
+
         $this->projects = Project::take(5)
             ->when($this->query, function($query, $term){
                 return $query->where('name', 'like', '%' . $term. '%');
             })
+            ->withMember($user)
             ->get()
             ->toArray();
         $this->showDropdown = true;

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Dashboard') }}
+            <span class="text-gray-500">{{ $team->name }} /</span> {{ __('Dashboard') }}
         </h2>
     </x-slot>
 

--- a/resources/views/projects/index.blade.php
+++ b/resources/views/projects/index.blade.php
@@ -1,7 +1,7 @@
 <x-app-layout>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('Projects') }}
+            <span class="text-gray-500">{{ $team->name }} /</span> {{ __('Projects') }}
         </h2>
 
         @can('create', \App\Models\Project::class)
@@ -39,8 +39,8 @@
                         <div>
                             <div class="truncate">{{ $project->team->name }}</div>
                         </div>
-                        <div>
-                            @foreach ($project->members as $member)
+                        <div class="flex space-x-1">
+                            @foreach ($project->allMembers() as $member)
                                 <x-user-avatar width="w-6" height="h-6" :user="$member" />
                             @endforeach
                         </div>

--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -14,12 +14,13 @@
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 flex flex-col-reverse md:flex-row space-x-6">
             <div class="flex-grow space-y-6">
-                
-                <div class="bg-gray-50 rounded-md shadow-lg p-4">
-                    <h3 class="font-bold mb-3">{{ __('Track time') }}</h3>
+                @can('create', [\App\Models\Task::class, $project])
+                    <div class="bg-gray-50 rounded-md shadow-lg p-4">
+                        <h3 class="font-bold mb-3">{{ __('Track time') }}</h3>
 
-                    <livewire:track-activity :project="$project" />
-                </div>
+                        <livewire:track-activity :project="$project" />
+                    </div>
+                @endcan
                 
                 <livewire:project-summary :project="$project" />
                 
@@ -65,8 +66,8 @@
                 </div>
                 <div class="pb-6 md:border-b border-gray-300">
                     <h3 class="font-bold mb-3">{{ __('Members') }}</h3>
-                    <div class="flex justify-between items-center">
-                        @foreach ($project->members as $member)
+                    <div class="flex items-center space-x-2">
+                        @foreach ($project->allMembers() as $member)
 
                             <x-user-avatar width="w-10" height="h-10" :user="$member" />
 
@@ -81,12 +82,14 @@
                         <li>
                             <a class="underline" href="{{ route('tasks.index', ['project' => $project]) }}">{{ __('View all tasks') }}</a>
                         </li>
-                        <li>
-                            <a class="underline" href="{{ route('tasks.import.create', ['project' => $project]) }}">{{ __('Import tasks') }}</a>
-                        </li>
-                        <li>
-                            <a class="underline" target="_blank" href="{{ route('tasks.export.show', ['project' => $project]) }}">{{ __('Export tasks') }}</a>
-                        </li>
+                        @can('create', [\App\Models\Task::class, $project])
+                            <li>
+                                <a class="underline" href="{{ route('tasks.import.create', ['project' => $project]) }}">{{ __('Import tasks') }}</a>
+                            </li>
+                            <li>
+                                <a class="underline" target="_blank" href="{{ route('tasks.export.show', ['project' => $project]) }}">{{ __('Export tasks') }}</a>
+                            </li>
+                        @endcan
                     </ul>
 
                     <x-jet-label>{{ __('Reference') }}</x-jet-label>

--- a/resources/views/tasks/index.blade.php
+++ b/resources/views/tasks/index.blade.php
@@ -18,7 +18,7 @@
             @endif
         </h2>
 
-        @can('create', \App\Models\Task::class)
+        @can('create', [\App\Models\Task::class, $filters['project'] ?? null])
             @php
                 $prj = optional($filters['project'] ?? null)->uuid
             @endphp


### PR DESCRIPTION
Registered users can be invited as team members therefore they can access the projects in the invited team.

With this pull request the team selector is honored in the dashboard and projects listing so that only projects of the selected team are presented. In addition team members are now listed.

Project creation in another team is subject to authorization, while task creation is only authorized in projects the user is an explicit member (currently still not possible to invite a user directly to a project).